### PR TITLE
fix: configure jekyll to include well-known directory (excluded by de…

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+include: [".well-known"]


### PR DESCRIPTION
Some [searching](https://duckduckgo.com/?q=%22github+pages%22+%22.well-known%22+404&t=ffab&ia=web) led through a few links and eventually to this:

> By default, Jekyll doesn't build files or folders that:
>
>    are located in a folder called /node_modules or /vendor
>    start with _, ., or #
>    end with ~
>    are excluded by the exclude setting in your configuration file
- https://help.github.com/en/github/working-with-github-pages/about-github-pages-and-jekyll#configuring-jekyll-in-your-github-pages-site

The [jekyll configuration](https://jekyllrb.com/docs/configuration/options/) with includes should help!
